### PR TITLE
Add GitHub Actions workflow for Go tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Go Test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test ./...


### PR DESCRIPTION
## Summary
- add simple Go test action using setup-go

## Testing
- `go test ./...` *(fails: cannot download modules)*

------
https://chatgpt.com/codex/tasks/task_e_683c669735ac832d9b48cef678f2ddd9