### PR TITLE
Add CI workflow for Go tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.2'
+      - name: Install swag
+        run: go install github.com/swaggo/swag/cmd/swag@latest
+      - name: Generate Swagger docs
+        run: swag init -g service.go -d cmd/service,internal/api,internal/handler
+      - name: Run tests
+        run: make test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs `swag`, generates docs, and runs `make test`

## Testing
- `go install github.com/swaggo/swag/cmd/swag@latest` *(fails: no route to host)*
- `swag init -g service.go -d cmd/service,internal/api,internal/handler`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683d08a21428832da93b4c517453b1f5