### PR TITLE
Add router and middleware tests

### DIFF
--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,0 +1,101 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"life-is-hard/internal/model"
+	"life-is-hard/internal/service"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func newContext(auth string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+func TestExtractClaims(t *testing.T) {
+	t.Setenv("JWT_SECRET", "testsecret")
+
+	// missing header
+	ctx, _ := newContext("")
+	_, err := extractClaims(ctx)
+	require.Error(t, err)
+
+	// bad format
+	ctx, _ = newContext("BadHeader")
+	_, err = extractClaims(ctx)
+	require.Error(t, err)
+
+	// invalid token
+	ctx, _ = newContext("Bearer invalid")
+	_, err = extractClaims(ctx)
+	require.Error(t, err)
+
+	// valid token
+	tok, err := service.IssueAccessToken(model.User{ID: 1, IsAdmin: true}, time.Minute)
+	require.NoError(t, err)
+	ctx, _ = newContext("Bearer " + tok)
+	claims, err := extractClaims(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, claims.UserID)
+	require.True(t, claims.IsAdmin)
+}
+
+func TestRequireAuth(t *testing.T) {
+	t.Setenv("JWT_SECRET", "secret")
+	tok, err := service.IssueAccessToken(model.User{ID: 2}, time.Minute)
+	require.NoError(t, err)
+
+	// success path
+	ctx, rec := newContext("Bearer " + tok)
+	called := false
+	handler := RequireAuth(func(c echo.Context) error {
+		called = true
+		cl := c.Get(ContextUserKey).(*service.CustomClaims)
+		require.Equal(t, 2, cl.UserID)
+		return c.String(http.StatusOK, "ok")
+	})
+	require.NoError(t, handler(ctx))
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// missing token
+	ctx, _ = newContext("")
+	called = false
+	err = RequireAuth(func(echo.Context) error { called = true; return nil })(ctx)
+	require.Error(t, err)
+	require.False(t, called)
+}
+
+func TestRequireAdmin(t *testing.T) {
+	t.Setenv("JWT_SECRET", "adminsecret")
+	adminTok, err := service.IssueAccessToken(model.User{ID: 3, IsAdmin: true}, time.Minute)
+	require.NoError(t, err)
+	userTok, err := service.IssueAccessToken(model.User{ID: 4, IsAdmin: false}, time.Minute)
+	require.NoError(t, err)
+
+	// admin ok
+	ctx, rec := newContext("Bearer " + adminTok)
+	called := false
+	err = RequireAdmin(func(c echo.Context) error { called = true; return c.String(http.StatusOK, "admin") })(ctx)
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// non-admin should fail
+	ctx, _ = newContext("Bearer " + userTok)
+	called = false
+	err = RequireAdmin(func(c echo.Context) error { called = true; return nil })(ctx)
+	require.Error(t, err)
+	require.False(t, called)
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,47 @@
+package router
+
+import (
+	"net/http"
+	"testing"
+
+	"life-is-hard/internal/cache"
+	"life-is-hard/internal/database"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupRoutes(t *testing.T) {
+	e := echo.New()
+	Setup(e, &database.FakeDB{}, &cache.FakeCache{})
+
+	got := map[string]struct{}{}
+	for _, r := range e.Routes() {
+		got[r.Method+" "+r.Path] = struct{}{}
+	}
+
+	expected := []string{
+		http.MethodGet + " /api/ping",
+		http.MethodPost + " /api/auth/login",
+		http.MethodPost + " /api/oauth/token",
+		http.MethodPost + " /api/users",
+		http.MethodGet + " /api/users/:id",
+		http.MethodPut + " /api/users/:id",
+		http.MethodDelete + " /api/users/:id",
+		http.MethodGet + " /api/users/me",
+		http.MethodPut + " /api/users/me",
+		http.MethodDelete + " /api/users/me",
+		http.MethodPatch + " /api/users/me/password",
+		http.MethodPost + " /api/users/me/oauth-clients",
+		http.MethodGet + " /api/users/me/oauth-clients",
+		http.MethodGet + " /api/users/me/oauth-clients/:client_id",
+		http.MethodPut + " /api/users/me/oauth-clients/:client_id",
+		http.MethodDelete + " /api/users/me/oauth-clients/:client_id",
+	}
+
+	require.Equal(t, len(expected), len(got))
+	for _, k := range expected {
+		_, ok := got[k]
+		require.True(t, ok, "missing route %s", k)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for router routes setup
- add middleware tests covering auth and admin middleware

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683eb30d7364832d8b7491df37a8a25a