### PR TITLE
Add tests for handlers and cache

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -6,10 +6,18 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// redisClient 抽象化 *redis.Client 方便測試時替換
+type redisClient interface {
+	Cache
+	Ping(ctx context.Context) *redis.StatusCmd
+}
+
+var redisNewClient = func(opt *redis.Options) redisClient { return redis.NewClient(opt) }
+
 // NewRedisClient 建立並回傳 *redis.Client，直接實作 Cache
 // addr: Redis 位址；password: 密碼，可空；db: 資料庫編號
 func NewRedisClient(addr string, password string, db int) (Cache, error) {
-	client := redis.NewClient(&redis.Options{
+	client := redisNewClient(&redis.Options{
 		Addr:     addr,
 		Password: password,
 		DB:       db,

--- a/internal/cache/redis_test.go
+++ b/internal/cache/redis_test.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRedis struct {
+	FakeCache
+	pingErr error
+}
+
+func (f *fakeRedis) Ping(ctx context.Context) *redis.StatusCmd {
+	return redis.NewStatusResult("PONG", f.pingErr)
+}
+
+func TestNewRedisClient(t *testing.T) {
+	orig := redisNewClient
+	defer func() { redisNewClient = orig }()
+
+	// ping failure
+	redisNewClient = func(opt *redis.Options) redisClient { return &fakeRedis{pingErr: errors.New("bad")} }
+	c, err := NewRedisClient("addr", "", 0)
+	require.Error(t, err)
+	require.Nil(t, c)
+
+	// success
+	r := &fakeRedis{}
+	redisNewClient = func(opt *redis.Options) redisClient { return r }
+	c, err = NewRedisClient("addr", "", 0)
+	require.NoError(t, err)
+	require.Equal(t, r, c)
+}

--- a/internal/handler/auth/login_test.go
+++ b/internal/handler/auth/login_test.go
@@ -1,0 +1,116 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"life-is-hard/internal/database"
+	"life-is-hard/internal/model"
+	"life-is-hard/internal/service"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// helper to build echo context
+func newLoginCtx(e *echo.Echo, body string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+type errBinder struct{}
+
+func (errBinder) Bind(i any, c echo.Context) error { return errors.New("bind") }
+
+type errValidator struct{}
+
+func (errValidator) Validate(i any) error { return errors.New("v") }
+
+type okValidator struct{}
+
+func (okValidator) Validate(i any) error { return nil }
+
+type fakeRow struct {
+	u   model.User
+	err error
+}
+
+func (r fakeRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	*dest[0].(*int) = r.u.ID
+	*dest[1].(*string) = r.u.Name
+	*dest[2].(*string) = r.u.Email
+	*dest[3].(*string) = r.u.PasswordHash
+	*dest[4].(*time.Time) = r.u.CreatedAt
+	*dest[5].(*bool) = r.u.IsAdmin
+	return nil
+}
+
+func TestLoginHandler(t *testing.T) {
+
+	// bind error
+	e := echo.New()
+	e.Binder = errBinder{}
+	ctx, rec := newLoginCtx(e, "")
+	h := LoginHandler(&database.FakeDB{})
+	require.NoError(t, h(ctx))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// validate error
+	e = echo.New()
+	e.Validator = errValidator{}
+	ctx, rec = newLoginCtx(e, "username=a&password=b")
+	h = LoginHandler(&database.FakeDB{QueryRowFn: func(context.Context, string, ...any) pgx.Row { return fakeRow{} }})
+	require.NoError(t, h(ctx))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// user not found
+	e = echo.New()
+	e.Validator = okValidator{}
+	ctx, rec = newLoginCtx(e, "username=a&password=b")
+	h = LoginHandler(&database.FakeDB{QueryRowFn: func(context.Context, string, ...any) pgx.Row { return fakeRow{err: errors.New("no")} }})
+	require.NoError(t, h(ctx))
+	t.Log("notfound", rec.Body.String())
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// authenticate error
+	e = echo.New()
+	e.Validator = okValidator{}
+	ctx, rec = newLoginCtx(e, "username=a&password=b")
+	badHash, _ := service.HashPassword("other")
+	h = LoginHandler(&database.FakeDB{QueryRowFn: func(context.Context, string, ...any) pgx.Row { return fakeRow{u: model.User{PasswordHash: badHash}} }})
+	require.NoError(t, h(ctx))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	t.Log("auth err", rec.Body.String())
+
+	// issue token error (JWT_SECRET not set)
+	e = echo.New()
+	e.Validator = okValidator{}
+	ctx, rec = newLoginCtx(e, "username=a&password=b")
+	goodHash, _ := service.HashPassword("b")
+	h = LoginHandler(&database.FakeDB{QueryRowFn: func(context.Context, string, ...any) pgx.Row { return fakeRow{u: model.User{PasswordHash: goodHash}} }})
+	require.NoError(t, h(ctx))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// success
+	e = echo.New()
+	e.Validator = okValidator{}
+	ctx, rec = newLoginCtx(e, "username=a&password=b")
+	t.Setenv("JWT_SECRET", "s")
+	h = LoginHandler(&database.FakeDB{QueryRowFn: func(context.Context, string, ...any) pgx.Row {
+		return fakeRow{u: model.User{ID: 1, PasswordHash: goodHash}}
+	}})
+	require.NoError(t, h(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "access_token")
+}

--- a/internal/handler/oauth/token_test.go
+++ b/internal/handler/oauth/token_test.go
@@ -1,0 +1,192 @@
+package oauth
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"life-is-hard/internal/cache"
+	"life-is-hard/internal/database"
+	"life-is-hard/internal/model"
+	"life-is-hard/internal/service"
+	"life-is-hard/internal/store"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// build context
+func newTokenCtx(e *echo.Echo, body, auth string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+type errBinder struct{}
+
+func (errBinder) Bind(i any, c echo.Context) error { return errors.New("bind") }
+
+type stubValidator struct{}
+
+func (stubValidator) Validate(i any) error { return nil }
+
+func restoreGlobals() {
+	getOAuthClientByClientID = store.GetOAuthClientByClientID
+	getUserByName = store.GetUserByName
+	getUserByID = store.GetUserByID
+	authenticateUser = service.AuthenticateUser
+	issueAccessToken = service.IssueAccessToken
+	issueRefreshToken = service.IssueRefreshToken
+	issueClientAccessToken = service.IssueClientAccessToken
+	validateRefreshToken = service.ValidateRefreshToken
+}
+
+func TestTokenHandler(t *testing.T) {
+	defer restoreGlobals()
+	e := echo.New()
+	e.Validator = stubValidator{}
+
+	// bind error
+	e.Binder = errBinder{}
+	ctx, rec := newTokenCtx(e, "", "")
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// bad auth prefix
+	e.Binder = &echo.DefaultBinder{}
+	ctx, rec = newTokenCtx(e, "grant_type=password", "bad")
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// bad base64
+	ctx, rec = newTokenCtx(e, "grant_type=password", "Basic ???")
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// missing colon
+	ctx, rec = newTokenCtx(e, "grant_type=password", "Basic "+base64.StdEncoding.EncodeToString([]byte("abc")))
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// invalid client credentials
+	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("id:sec"))
+	getOAuthClientByClientID = func(_ context.Context, _ database.DB, _ string) (*model.OAuthClient, error) {
+		return &model.OAuthClient{ClientID: "id", ClientSecret: "other"}, nil
+	}
+	ctx, rec = newTokenCtx(e, "grant_type=password", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// unauthorized grant type
+	getOAuthClientByClientID = func(_ context.Context, _ database.DB, _ string) (*model.OAuthClient, error) {
+		return &model.OAuthClient{ClientID: "id", ClientSecret: "sec", GrantTypes: []string{"client_credentials"}}, nil
+	}
+	ctx, rec = newTokenCtx(e, "grant_type=password", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// password grant user not found
+	getOAuthClientByClientID = func(_ context.Context, _ database.DB, _ string) (*model.OAuthClient, error) {
+		return &model.OAuthClient{ClientID: "id", ClientSecret: "sec", GrantTypes: []string{"password"}}, nil
+	}
+	getUserByName = func(context.Context, database.DB, string) (*model.User, error) { return nil, errors.New("no") }
+	ctx, rec = newTokenCtx(e, "grant_type=password", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// password grant auth fail
+	getUserByName = func(context.Context, database.DB, string) (*model.User, error) { return &model.User{}, nil }
+	authenticateUser = func(context.Context, model.User, string) error { return errors.New("bad") }
+	ctx, rec = newTokenCtx(e, "grant_type=password", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// password grant issueAccessToken error
+	authenticateUser = func(context.Context, model.User, string) error { return nil }
+	issueAccessToken = func(model.User, time.Duration) (string, error) { return "", errors.New("x") }
+	ctx, rec = newTokenCtx(e, "grant_type=password", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// password grant issueRefreshToken error
+	issueAccessToken = func(model.User, time.Duration) (string, error) { return "tok", nil }
+	issueRefreshToken = func(context.Context, cache.Cache, int, string, bool, time.Duration) (string, error) {
+		return "", errors.New("x")
+	}
+	ctx, rec = newTokenCtx(e, "grant_type=password", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// password grant success
+	issueRefreshToken = func(context.Context, cache.Cache, int, string, bool, time.Duration) (string, error) { return "rt", nil }
+	ctx, rec = newTokenCtx(e, "grant_type=password", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "rt")
+
+	// client_credentials owner error
+	getOAuthClientByClientID = func(_ context.Context, _ database.DB, _ string) (*model.OAuthClient, error) {
+		return &model.OAuthClient{ClientID: "id", ClientSecret: "sec", GrantTypes: []string{"client_credentials"}, UserID: 1}, nil
+	}
+	getUserByID = func(context.Context, database.DB, int) (*model.User, error) { return nil, errors.New("x") }
+	ctx, rec = newTokenCtx(e, "grant_type=client_credentials", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// client_credentials issue error
+	getUserByID = func(context.Context, database.DB, int) (*model.User, error) { return &model.User{}, nil }
+	issueClientAccessToken = func(model.User, model.OAuthClient, time.Duration) (string, error) { return "", errors.New("x") }
+	ctx, rec = newTokenCtx(e, "grant_type=client_credentials", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// client_credentials success
+	issueClientAccessToken = func(model.User, model.OAuthClient, time.Duration) (string, error) { return "tok", nil }
+	ctx, rec = newTokenCtx(e, "grant_type=client_credentials", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// refresh_token validate error
+	getOAuthClientByClientID = func(_ context.Context, _ database.DB, _ string) (*model.OAuthClient, error) {
+		return &model.OAuthClient{ClientID: "id", ClientSecret: "sec", GrantTypes: []string{"refresh_token"}}, nil
+	}
+	validateRefreshToken = func(context.Context, cache.Cache, string) (*service.RefreshTokenData, error) {
+		return nil, errors.New("bad")
+	}
+	ctx, rec = newTokenCtx(e, "grant_type=refresh_token&refresh_token=rt", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// refresh_token issue access error
+	validateRefreshToken = func(context.Context, cache.Cache, string) (*service.RefreshTokenData, error) {
+		return &service.RefreshTokenData{UserID: 2}, nil
+	}
+	issueAccessToken = func(model.User, time.Duration) (string, error) { return "", errors.New("x") }
+	ctx, rec = newTokenCtx(e, "grant_type=refresh_token&refresh_token=rt", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// refresh_token success
+	issueAccessToken = func(model.User, time.Duration) (string, error) { return "tok", nil }
+	ctx, rec = newTokenCtx(e, "grant_type=refresh_token&refresh_token=rt", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "refresh_token\":\"rt")
+
+	// unsupported grant
+	getOAuthClientByClientID = func(_ context.Context, _ database.DB, _ string) (*model.OAuthClient, error) {
+		return &model.OAuthClient{ClientID: "id", ClientSecret: "sec", GrantTypes: []string{"unknown"}}, nil
+	}
+	ctx, rec = newTokenCtx(e, "grant_type=unknown", auth)
+	require.NoError(t, TokenHandler(nil, nil)(ctx))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/handler/ping_test.go
+++ b/internal/handler/ping_test.go
@@ -1,0 +1,60 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"life-is-hard/internal/cache"
+	"life-is-hard/internal/database"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func newPingCtx() (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+func TestPingHandler(t *testing.T) {
+	// db error
+	ctx, rec := newPingCtx()
+	db := &database.FakeDB{
+		QueryRowFn: func(context.Context, string, ...any) pgx.Row { return nil },
+		PingFn:     func(context.Context) error { return errors.New("db") },
+	}
+	h := PingHandler(db, &cache.FakeCache{})
+	require.NoError(t, h(ctx))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// cache error
+	ctx, rec = newPingCtx()
+	c := &cache.FakeCache{SetFn: func(context.Context, string, any, time.Duration) *redis.StatusCmd {
+		return redis.NewStatusResult("", errors.New("cache"))
+	}}
+	db = &database.FakeDB{
+		QueryRowFn: func(context.Context, string, ...any) pgx.Row { return nil },
+		PingFn:     func(context.Context) error { return nil },
+	}
+	h = PingHandler(db, c)
+	require.NoError(t, h(ctx))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// success
+	ctx, rec = newPingCtx()
+	c = &cache.FakeCache{SetFn: func(context.Context, string, any, time.Duration) *redis.StatusCmd {
+		return redis.NewStatusResult("OK", nil)
+	}}
+	h = PingHandler(db, c)
+	require.NoError(t, h(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "pong")
+}


### PR DESCRIPTION
## Summary
- refactor Redis client creation and OAuth token handler for easier testing
- add unit tests for Redis client, login handler, token handler and ping handler
- achieve full coverage on those components

## Testing
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_683eb8d2bcd8832d8363f6989e67df00