### PR TITLE
Add redis client unit tests

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -6,10 +6,21 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// redisClient 定義了 NewRedisClient 內部使用的必要方法，便於測試時替換。
+type redisClient interface {
+	Cache
+	Ping(ctx context.Context) *redis.StatusCmd
+}
+
+// redisNewClient 用來建立 redis client，測試可覆寫此變數。
+var redisNewClient = func(opt *redis.Options) redisClient {
+	return redis.NewClient(opt)
+}
+
 // NewRedisClient 建立並回傳 *redis.Client，直接實作 Cache
 // addr: Redis 位址；password: 密碼，可空；db: 資料庫編號
 func NewRedisClient(addr string, password string, db int) (Cache, error) {
-	client := redis.NewClient(&redis.Options{
+	client := redisNewClient(&redis.Options{
 		Addr:     addr,
 		Password: password,
 		DB:       db,

--- a/internal/cache/redis_test.go
+++ b/internal/cache/redis_test.go
@@ -1,0 +1,60 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// stubClient implements redisClient for testing.
+type stubClient struct {
+	pingErr error
+}
+
+func (s *stubClient) Ping(ctx context.Context) *redis.StatusCmd {
+	return redis.NewStatusResult("PONG", s.pingErr)
+}
+
+func (s *stubClient) Get(ctx context.Context, key string) *redis.StringCmd {
+	return redis.NewStringResult("", nil)
+}
+
+func (s *stubClient) Set(ctx context.Context, key string, value interface{}, ttl time.Duration) *redis.StatusCmd {
+	return redis.NewStatusResult("OK", nil)
+}
+
+func (s *stubClient) Close() error { return nil }
+
+func TestNewRedisClient(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var opts *redis.Options
+		stub := &stubClient{}
+		redisNewClient = func(o *redis.Options) redisClient {
+			opts = o
+			return stub
+		}
+		defer func() { redisNewClient = func(o *redis.Options) redisClient { return redis.NewClient(o) } }()
+
+		c, err := NewRedisClient("127.0.0.1:6379", "secret", 1)
+		require.NoError(t, err)
+		require.Equal(t, stub, c)
+		require.Equal(t, "127.0.0.1:6379", opts.Addr)
+		require.Equal(t, "secret", opts.Password)
+		require.Equal(t, 1, opts.DB)
+	})
+
+	t.Run("ping fail", func(t *testing.T) {
+		redisNewClient = func(o *redis.Options) redisClient {
+			return &stubClient{pingErr: errors.New("fail")}
+		}
+		defer func() { redisNewClient = func(o *redis.Options) redisClient { return redis.NewClient(o) } }()
+
+		c, err := NewRedisClient("addr", "", 0)
+		require.Error(t, err)
+		require.Nil(t, c)
+	})
+}


### PR DESCRIPTION
## Summary
- add test doubles for Redis client
- allow injecting Redis client constructor
- cover `NewRedisClient` with unit tests

## Testing
- `go test ./...`
- `go test -coverprofile=coverage.out ./internal/cache`


------
https://chatgpt.com/codex/tasks/task_e_683fb22650f0832da4e5dac36a439b66