### PR TITLE
Enforce full coverage in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,7 @@ dev: $(AIR) $(SWAG)
 test:
 	@go test -coverprofile=coverage.out -coverpkg=./... ./...
 	@go tool cover -func=coverage.out
+	@if ! go tool cover -func=coverage.out | grep -q '100.0%'; then \
+	       echo "Coverage must be 100%"; \
+	       exit 1; \
+	fi


### PR DESCRIPTION
## Summary
- update `make test` target to fail when coverage is below 100%

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683ffb349978832d91a5bfaa8ce00b3f