### PR TITLE
Add Dockerfile for production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Ignore the temporary build output
+/tmp
+.docs
+coverage.out
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM golang:1.24.3-alpine AS build
+WORKDIR /src
+# Install build dependencies
+RUN apk add --no-cache git
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+# Copy the source code
+COPY . .
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /app/service cmd/service/service.go
+
+# Run stage
+FROM alpine:latest
+WORKDIR /app
+COPY --from=build /app/service ./service
+# Make sure the binary is executable
+RUN chmod +x ./service
+EXPOSE 8080
+CMD ["./service"]


### PR DESCRIPTION
## Summary
- add Dockerfile for building and running the Go service
- ignore build artifacts with `.dockerignore`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68400d5cfcf4832d97fff021abea1527