### PR TITLE
Add Helm chart for backend

### DIFF
--- a/chart/life-is-hard/Chart.yaml
+++ b/chart/life-is-hard/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: life-is-hard
+description: Helm chart for the life-is-hard backend service
+version: 0.1.0
+appVersion: "1.0.0"
+type: application
+
+dependencies:
+  - name: postgresql
+    version: "12.9.1"
+    repository: "https://charts.bitnami.com/bitnami"
+  - name: redis
+    version: "18.3.2"
+    repository: "https://charts.bitnami.com/bitnami"

--- a/chart/life-is-hard/README.md
+++ b/chart/life-is-hard/README.md
@@ -1,0 +1,14 @@
+# life-is-hard Helm Chart
+
+This chart deploys the `life-is-hard` backend service along with Postgres and Redis using Bitnami subcharts.
+
+## Configuration
+
+All configurable parameters are documented in `values.yaml`. Defaults target a production setup with persistence enabled for both Postgres and Redis and two application replicas.
+
+Install the chart with:
+
+```bash
+helm install my-release ./chart/life-is-hard
+```
+

--- a/chart/life-is-hard/templates/_helpers.tpl
+++ b/chart/life-is-hard/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{- define "life-is-hard.name" -}}
+{{- .Chart.Name -}}
+{{- end -}}
+
+{{- define "life-is-hard.fullname" -}}
+{{- printf "%s-%s" .Release.Name (include "life-is-hard.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "life-is-hard.chart" -}}
+{{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end -}}
+
+{{- define "life-is-hard.labels" -}}
+helm.sh/chart: {{ include "life-is-hard.chart" . }}
+app.kubernetes.io/name: {{ include "life-is-hard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "life-is-hard.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "life-is-hard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "life-is-hard.postgresql.fullname" -}}
+{{ printf "%s-postgresql" .Release.Name }}
+{{- end -}}
+
+{{- define "life-is-hard.redis.fullname" -}}
+{{ printf "%s-redis" .Release.Name }}
+{{- end -}}

--- a/chart/life-is-hard/templates/deployment.yaml
+++ b/chart/life-is-hard/templates/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "life-is-hard.fullname" . }}
+  labels:
+    {{- include "life-is-hard.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "life-is-hard.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "life-is-hard.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DATABASE_URL
+              value: "postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ include \"life-is-hard.postgresql.fullname\" . }}:5432/{{ .Values.postgresql.auth.database }}"
+            - name: REDIS_ADDR
+              value: "{{ include \"life-is-hard.redis.fullname\" . }}-master:6379"
+            - name: REDIS_DB
+              value: "{{ .Values.env.redisDb }}"
+            - name: REDIS_PASSWORD
+              value: "{{ .Values.redis.auth.password }}"
+            - name: JWT_SECRET
+              value: "{{ .Values.env.jwtSecret }}"
+            - name: WORKER_PROCESSES
+              value: "{{ .Values.env.workerProcesses }}"
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/chart/life-is-hard/templates/service.yaml
+++ b/chart/life-is-hard/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "life-is-hard.fullname" . }}
+  labels:
+    {{- include "life-is-hard.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "life-is-hard.selectorLabels" . | nindent 4 }}

--- a/chart/life-is-hard/values.yaml
+++ b/chart/life-is-hard/values.yaml
@@ -1,0 +1,35 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/example/life-is-hard
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+env:
+  workerProcesses: "4"
+  jwtSecret: "CHANGE_ME"
+  redisDb: "0"
+
+resources: {}
+
+postgresql:
+  auth:
+    username: lifeishard
+    password: strong-db-pass
+    database: lifeishard
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi
+
+redis:
+  auth:
+    password: strong-redis-pass
+  master:
+    persistence:
+      enabled: true
+      size: 2Gi


### PR DESCRIPTION
## Summary
- add chart for `life-is-hard` backend service
- configure values.yaml with production defaults
- document usage

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68400f3e6008832d8ddbe6b3685f23d7