### PR TITLE
Add docker-compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # life-is-hard
+
+This project provides a simple Go service. A Docker compose configuration is included to help start the service along with PostgreSQL and Redis.
+
+## Quick start
+
+```bash
+docker compose up --build
+```
+
+The API will be available at [http://localhost:8080](http://localhost:8080).
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:latest
+    container_name: life-is-hard-postgres
+    environment:
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:latest
+    container_name: life-is-hard-redis
+    command: redis-server --requirepass password
+    ports:
+      - "6380:6379"
+    volumes:
+      - redis-data:/data
+
+  service:
+    build: .
+    container_name: life-is-hard-service
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      DATABASE_URL: postgres://postgres:password@postgres:5432/postgres
+      REDIS_ADDR: redis:6379
+      REDIS_DB: "0"
+      REDIS_PASSWORD: password
+      JWT_SECRET: jwt-secret-dev
+      WORKER_PROCESSES: "1"
+    ports:
+      - "8080:8080"
+
+volumes:
+  postgres-data:
+  redis-data:


### PR DESCRIPTION
## Summary
- include `docker-compose.yml` that runs the service, Postgres and Redis
- document running the stack via docker compose

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840fb44fa58832db7b2d3c622a1b177